### PR TITLE
Save model on gui destruction

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -74,7 +74,6 @@ Application {
             }
             onReleased: {
                 held = false
-                saveModel()
             }
 
             Rectangle {
@@ -277,6 +276,9 @@ Application {
 
                     Item { width: parent.width; height: Dims.l(10) }
                 }
+            }
+            Component.onDestruction: {
+                saveModel()
             }
         }
     }


### PR DESCRIPTION
The previous version only saved the model when a city was held and then released.  The correct operation, implemented here, saves the model when the GUI is destroyed, assuring that the latest model is always saved. This fixes issue #2.