### PR TITLE
Return non-zero exit code on error

### DIFF
--- a/src/UrlFetcher.cpp
+++ b/src/UrlFetcher.cpp
@@ -15,6 +15,10 @@ void UrlFetcher::fetch(QUrl url)
 }
 
 void UrlFetcher::replyFinished(QNetworkReply *reply) {
+    auto err = reply->error();
+    if (err) {
+        qInfo() << "Error:" << err;
+    }
     QString str = reply->readAll();
     emit receivedData(str);
     emit done();

--- a/src/UrlFetcher.cpp
+++ b/src/UrlFetcher.cpp
@@ -16,7 +16,7 @@ void UrlFetcher::fetch(QUrl url)
 
 void UrlFetcher::replyFinished(QNetworkReply *reply) {
     auto err = reply->error();
-    if (err) {
+    if (err != QNetworkReply::NoError) {
         qInfo() << "Error:" << err;
     }
     QString str = reply->readAll();

--- a/src/WeatherParser.cpp
+++ b/src/WeatherParser.cpp
@@ -229,8 +229,8 @@ void WeatherParser::update(QString cityname, QString weatherJson)
 {
     using namespace std::chrono_literals;
     if (cityname == nullptr || weatherJson == nullptr) {
-        qDebug() << "Error!  arguments to WeatherParser::update were null";
-        emit done();
+        qDebug() << "Error: arguments to WeatherParser::update were null";
+        emit exit(1);
     }
     updateWeather(cityname, weatherJson);
     g_settings_sync();


### PR DESCRIPTION
This fixes #9 and #10 by printing a diagnostic message if there is an error when fetching the weather data and also by returning with a non-zero return code in the event of a detected problem such as a null string for either the city name or the weather data.